### PR TITLE
✨ Ajout d'un bouton « Ajouter à l'agenda » (.ics) sur les sessions

### DIFF
--- a/app/components/add_to_calendar_component.html.erb
+++ b/app/components/add_to_calendar_component.html.erb
@@ -1,0 +1,6 @@
+<%# `data-turbo="false"` lets the browser handle the .ics natively (download / open in Calendar)
+    instead of Turbo Drive trying to render it as a page. %>
+<%= content_tag :a, href: url, class: classes, download: filename, data: { turbo: false } do %>
+  <%= lucide_icon(icon, class: "size-5", aria: { hidden: true }) %>
+  <span><%= label %></span>
+<% end %>

--- a/app/components/add_to_calendar_component.rb
+++ b/app/components/add_to_calendar_component.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+# Self-contained "Add to calendar" button. Point it at a .ics endpoint and it renders a
+# link that lets the user add the event to Apple Calendar, Google Calendar or Outlook.
+#
+# Fully exportable: it knows nothing about sessions or any specific model — it only needs
+# a URL. Reuse it anywhere by rendering:
+#
+#   render AddToCalendarComponent.new(url: calendar_session_path(@session, format: :ics))
+#
+# Options:
+#   url:        (required) href of the .ics resource
+#   label:      button text
+#   variant:    :secondary (default), :primary, :ghost
+#   size:       :small, :medium (default), :large
+#   icon:       lucide icon name (default "calendar-plus")
+#   full_width: stretch to container width (default true)
+#   filename:   value for the anchor's `download` attribute (optional)
+class AddToCalendarComponent < ApplicationComponent
+  def initialize(url:, label: "Ajouter à l'agenda", variant: :secondary, size: :medium,
+                 icon: "calendar-plus", full_width: true, filename: nil)
+    @url = url
+    @label = label
+    @variant = variant
+    @size = size
+    @icon = icon
+    @full_width = full_width
+    @filename = filename
+  end
+
+  private
+
+  attr_reader :url, :label, :variant, :size, :icon, :full_width, :filename
+
+  def classes
+    [
+      "inline-flex items-center justify-center gap-2 font-semibold rounded-none",
+      "focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors duration-150",
+      ("w-full" if full_width),
+      size_classes,
+      variant_classes
+    ].compact.join(" ")
+  end
+
+  def size_classes
+    case size.to_sym
+    when :small then "px-3 py-2 text-sm"
+    when :large then "px-5 py-3 text-base"
+    else "px-4 py-2 text-sm"
+    end
+  end
+
+  def variant_classes
+    case variant.to_sym
+    when :primary
+      "bg-asmbv-red text-white hover:bg-asmbv-red-dark focus:ring-asmbv-red"
+    when :ghost
+      "bg-transparent border border-transparent text-gray-900 hover:bg-gray-100 focus:ring-gray-400"
+    else # :secondary
+      "bg-gray-100 border border-gray-200 text-gray-900 hover:bg-gray-200 focus:ring-asmbv-red"
+    end
+  end
+end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,7 +3,7 @@
 class SessionsController < ApplicationController
   before_action :authenticate_user!
   load_and_authorize_resource
-  before_action :set_session, only: [ :show, :edit, :update, :destroy ]
+  before_action :set_session, only: [ :show, :edit, :update, :destroy, :calendar ]
   before_action :set_session_for_cancel, only: [ :cancel ]
   before_action :set_session_for_duplicate, only: []
 
@@ -84,6 +84,14 @@ class SessionsController < ApplicationController
 
       @candidate_users = base.order(:first_name, :last_name).distinct
     end
+  end
+
+  def calendar
+    export = Sessions::IcsExport.new(@session, url: session_url(@session))
+    send_data export.call,
+              type: "text/calendar; charset=utf-8",
+              disposition: "attachment",
+              filename: export.filename
   end
 
   def new

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -6,6 +6,9 @@ class Ability
   def initialize(user)
     user ||= User.new
 
+    # Downloading a session's .ics is a read-only capability.
+    alias_action :calendar, to: :read
+
     if user.admin?
       can :manage, :all
       return

--- a/app/services/ics/calendar.rb
+++ b/app/services/ics/calendar.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Ics
+  # Serializes one or more Ics::Event objects into a valid iCalendar (RFC 5545) document.
+  # Framework-agnostic: give it events, get back a .ics string that Apple Calendar,
+  # Google Calendar and Outlook can all import.
+  class Calendar
+    PRODID = "-//AS Monaco Beach Volley//Sessions//FR"
+    MAX_OCTETS = 75
+
+    def self.call(events)
+      new(events).to_ics
+    end
+
+    def initialize(events)
+      @events = Array(events)
+    end
+
+    def to_ics
+      lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:#{PRODID}",
+        "CALSCALE:GREGORIAN",
+        "METHOD:PUBLISH"
+      ]
+      @events.each { |event| lines.concat(event_lines(event)) }
+      lines << "END:VCALENDAR"
+      lines.map { |line| fold(line) }.join("\r\n") + "\r\n"
+    end
+
+    private
+
+    def event_lines(event)
+      [
+        "BEGIN:VEVENT",
+        "UID:#{event.uid}",
+        "DTSTAMP:#{format_time(Time.now)}",
+        "DTSTART:#{format_time(event.starts_at)}",
+        "DTEND:#{format_time(event.ends_at)}",
+        "SUMMARY:#{escape(event.title)}",
+        *optional_line("DESCRIPTION", event.description),
+        *optional_line("LOCATION", event.location),
+        *optional_line("URL", event.url),
+        "END:VEVENT"
+      ]
+    end
+
+    def optional_line(name, value)
+      value.present? ? [ "#{name}:#{escape(value)}" ] : []
+    end
+
+    def format_time(time)
+      time.utc.strftime("%Y%m%dT%H%M%SZ")
+    end
+
+    # RFC 5545 TEXT escaping.
+    def escape(text)
+      text.to_s
+          .gsub(/\r\n?/, "\n")
+          .gsub(/[\\;,\n]/) do |char|
+            case char
+            when "\\" then "\\\\"
+            when ";" then "\\;"
+            when "," then "\\,"
+            when "\n" then "\\n"
+            end
+          end
+    end
+
+    # RFC 5545 line folding: content lines longer than 75 octets are split, with each
+    # continuation line prefixed by a single space. Splits on character boundaries so
+    # multibyte UTF-8 is never cut in half.
+    def fold(line)
+      return line if line.bytesize <= MAX_OCTETS
+
+      folded = +""
+      current = +""
+      limit = MAX_OCTETS
+      line.each_char do |char|
+        if current.bytesize + char.bytesize > limit
+          folded << current << "\r\n "
+          current = +"#{char}"
+          limit = MAX_OCTETS - 1 # continuation lines reserve one octet for the leading space
+        else
+          current << char
+        end
+      end
+      folded << current
+    end
+  end
+end

--- a/app/services/ics/event.rb
+++ b/app/services/ics/event.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Ics
+  # Value object describing a single calendar event, framework-agnostic.
+  # Times must be Time/DateTime objects; they are serialized in UTC by Ics::Calendar.
+  Event = Data.define(:uid, :title, :starts_at, :ends_at, :description, :location, :url) do
+    def initialize(uid:, title:, starts_at:, ends_at:, description: nil, location: nil, url: nil)
+      super
+    end
+  end
+end

--- a/app/services/sessions/ics_export.rb
+++ b/app/services/sessions/ics_export.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Sessions
+  # Turns a Session into a downloadable .ics document. This is the only piece that knows
+  # about the Session model; the actual iCalendar formatting lives in the reusable
+  # Ics::Calendar serializer.
+  class IcsExport
+    def self.call(session, url: nil)
+      new(session, url: url).call
+    end
+
+    def initialize(session, url: nil)
+      @session = session
+      @url = url
+    end
+
+    def call
+      Ics::Calendar.call(event)
+    end
+
+    def filename
+      "asmbv-session-#{session.id}.ics"
+    end
+
+    private
+
+    attr_reader :session, :url
+
+    def event
+      Ics::Event.new(
+        uid: "session-#{session.id}@asmbv",
+        title: session.title.presence || session.display_name,
+        starts_at: session.start_at,
+        ends_at: session.end_at,
+        description: session.description.presence,
+        location: location,
+        url: url
+      )
+    end
+
+    def location
+      [ "AS Monaco Beach Volley", session.terrain ].compact.join(" — ")
+    end
+  end
+end

--- a/app/views/sessions/_hero_cta.html.erb
+++ b/app/views/sessions/_hero_cta.html.erb
@@ -45,6 +45,12 @@
       <% end %>
     <% end %>
 
+    <% unless existing_registration.waitlisted? %>
+      <div class="mt-3">
+        <%= render AddToCalendarComponent.new(url: calendar_session_path(session, format: :ics)) %>
+      </div>
+    <% end %>
+
     <% if !existing_registration.waitlisted? && session.entrainement? && session.cancellation_deadline_at.present? %>
       <div class="mt-3">
         <% if Time.current > session.cancellation_deadline_at %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
   end
   resources :sessions do
     post :cancel, on: :member
+    get :calendar, on: :member
     resources :registrations, only: [ :create, :destroy ]
   end
 


### PR DESCRIPTION
Bouton affiché aux inscrits confirmés, télécharge un .ics universel (Apple Calendar / Google / Outlook).

- AddToCalendarComponent : composant exportable (ne connaît qu'une URL)
- Ics::Event + Ics::Calendar : sérialiseur iCalendar RFC 5545 réutilisable
- Sessions::IcsExport : mapping Session -> .ics
- Route membre GET /sessions/:id/calendar.ics + action send_data
- alias_action :calendar -> :read (autorisation)