### PR TITLE
✨ Bouton « Ajouter à l'agenda » (.ics) sur les sessions

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -88,9 +88,12 @@ class SessionsController < ApplicationController
 
   def calendar
     export = Sessions::IcsExport.new(@session, url: session_url(@session))
+    # `inline` : sur iOS Safari, ouvre directement l'écran « Ajouter l'événement »
+    # dans Calendar au lieu d'enregistrer le fichier. Le filename reste utile pour
+    # les plateformes qui téléchargent quand même (Android, desktop).
     send_data export.call,
               type: "text/calendar; charset=utf-8",
-              disposition: "attachment",
+              disposition: "inline",
               filename: export.filename
   end
 


### PR DESCRIPTION
## Quoi

Ajoute un bouton **« Ajouter à l'agenda »** dans le CTA de la page détail d'une session. Affiché aux inscrits confirmés, il génère un fichier `.ics` universel :
- iPhone (Safari) → ouvre **directement** l'écran « Ajouter l'événement » dans Apple Calendar (`Content-Disposition: inline`)
- Android / desktop → import dans Google Calendar / Outlook

## Pourquoi

Permettre aux joueur·ses de retrouver facilement leurs créneaux dans leur agenda perso, sans ressaisie.

## Comment

- **`AddToCalendarComponent`** : composant ViewComponent **exportable** — il ne connaît qu'une URL, réutilisable partout (`render AddToCalendarComponent.new(url: ...)`).
- **`Ics::Event` + `Ics::Calendar`** : sérialiseur iCalendar **RFC 5545** générique et réutilisable (échappement `\; \, \n`, pliage des lignes à 75 octets sans couper l'UTF-8, horaires en UTC, fins de ligne CRLF).
- **`Sessions::IcsExport`** : seul point qui connaît le modèle `Session` (mapping Session → `.ics`).
- Route membre `GET /sessions/:id/calendar.ics` + action `send_data` en `disposition: inline`.
- `alias_action :calendar, to: :read` : le téléchargement suit l'autorisation de lecture d'une session.

## Notes pour la revue

- Bouton placé sous « Je me désinscris », **masqué en liste d'attente** (`unless waitlisted?`).
- Style : `variant: :secondary` (gris) pour ne pas rivaliser avec le CTA rouge de désinscription. Reprend les classes de `ButtonComponent` + icônes `lucide` (cohérent avec le reste du CTA).
- `inline` optimise surtout iOS ; Android télécharge le `.ics` quoi qu'il arrive puis propose de l'ouvrir (limitation plateforme).
- Non testé dans un vrai navigateur (base de dev vide, aucune session). Vérifs faites en console : ICS valide, route, autorisation (`read` ⇒ `calendar`), rendu du composant. RuboCop OK.
- Les `package-lock.json` / `yarn.lock` modifiés en local (antérieurs, sans rapport) ne sont pas inclus.