### PR TITLE
✨ Annonces de jeu libre (matcher de joueurs)

### DIFF
--- a/app/components/whatsapp_share_component.html.erb
+++ b/app/components/whatsapp_share_component.html.erb
@@ -1,0 +1,4 @@
+<%= content_tag :a, href: href, class: classes, target: "_blank", rel: "noopener", data: { turbo: false } do %>
+  <%= lucide_icon(icon, class: "size-5", aria: { hidden: true }) %>
+  <span><%= label %></span>
+<% end %>

--- a/app/components/whatsapp_share_component.rb
+++ b/app/components/whatsapp_share_component.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# Self-contained "Partager sur WhatsApp" button. Point it at a pre-filled text
+# and it renders a link opening WhatsApp's share sheet (the user picks the
+# group/contact). No API, no phone number required.
+#
+#   render WhatsappShareComponent.new(text: "Jeu libre samedi 10h, Terrain 1 …")
+#
+# Options mirror AddToCalendarComponent for a consistent look & feel.
+class WhatsappShareComponent < ApplicationComponent
+  def initialize(text:, label: "Partager sur WhatsApp", variant: :primary, size: :medium,
+                 icon: "message-circle", full_width: true)
+    @text = text
+    @label = label
+    @variant = variant
+    @size = size
+    @icon = icon
+    @full_width = full_width
+  end
+
+  private
+
+  attr_reader :text, :label, :variant, :size, :icon, :full_width
+
+  def href
+    "https://wa.me/?text=#{CGI.escape(text.to_s)}"
+  end
+
+  def classes
+    [
+      "inline-flex items-center justify-center gap-2 font-semibold rounded-none",
+      "focus:outline-none focus:ring-2 focus:ring-offset-2 transition-colors duration-150",
+      ("w-full" if full_width),
+      size_classes,
+      variant_classes
+    ].compact.join(" ")
+  end
+
+  def size_classes
+    case size.to_sym
+    when :small then "px-3 py-2 text-sm"
+    when :large then "px-5 py-3 text-base"
+    else "px-4 py-2 text-sm"
+    end
+  end
+
+  def variant_classes
+    case variant.to_sym
+    when :secondary
+      "bg-gray-100 border border-gray-200 text-gray-900 hover:bg-gray-200 focus:ring-asmbv-red"
+    when :ghost
+      "bg-transparent border border-transparent text-gray-900 hover:bg-gray-100 focus:ring-gray-400"
+    else # :primary — vert WhatsApp
+      "bg-[#25D366] text-white hover:bg-[#1ebe5d] focus:ring-[#25D366]"
+    end
+  end
+end

--- a/app/controllers/annonces_controller.rb
+++ b/app/controllers/annonces_controller.rb
@@ -1,0 +1,124 @@
+# frozen_string_literal: true
+
+class AnnoncesController < ApplicationController
+  before_action :authenticate_user!
+  before_action :set_annonce, only: [ :show, :edit, :update, :destroy, :confirm, :cancel, :toggle_availability ]
+
+  def index
+    authorize! :read, Annonce
+    @eligible_annonces = Annonces::EligibleAnnoncesQuery.call(user: current_user)
+    @my_annonces = Annonce.where(user_id: current_user.id).ordered_by_recent.includes(:levels, slots: :availabilities)
+  end
+
+  def show
+    authorize! :read, @annonce
+    @available_slot_ids = current_slot_ids_for(current_user)
+  end
+
+  def new
+    authorize! :create, Annonce
+    @annonce = Annonce.new
+    2.times { @annonce.slots.build }
+  end
+
+  def create
+    @annonce = Annonce.new(annonce_params)
+    @annonce.user = current_user
+    authorize! :create, @annonce
+
+    if @annonce.save
+      Annonces::CreationNotifier.new(annonce: @annonce).notify_eligible_players
+      redirect_to @annonce, notice: "Annonce publiée ✅ Les joueurs éligibles ont été prévenus."
+    else
+      @annonce.slots.build if @annonce.slots.empty?
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def edit
+    authorize! :update, @annonce
+  end
+
+  def update
+    authorize! :update, @annonce
+    if @annonce.update(annonce_params)
+      redirect_to @annonce, notice: "Annonce mise à jour ✅"
+    else
+      @annonce.slots.build if @annonce.slots.empty?
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  def destroy
+    authorize! :destroy, @annonce
+    @annonce.destroy
+    redirect_to annonces_path, notice: "Annonce supprimée."
+  end
+
+  # Un joueur (dé)clare sa disponibilité sur un créneau de l'annonce.
+  def toggle_availability
+    authorize! :toggle_availability, @annonce
+    slot = @annonce.slots.find(params[:slot_id])
+    availability = AnnonceAvailability.find_by(annonce_slot: slot, user: current_user)
+
+    if availability
+      availability.destroy
+    else
+      AnnonceAvailability.create(annonce_slot: slot, user: current_user)
+      Annonces::CreationNotifier.new(annonce: @annonce).notify_creator_of_response(from: current_user)
+    end
+
+    redirect_to @annonce
+  end
+
+  # GET : formulaire de choix du créneau + terrain. PATCH : confirmation effective.
+  def confirm
+    authorize! :confirm, @annonce
+
+    if request.get?
+      @confirmable_slots = @annonce.confirmable_slots
+      @terrains_by_slot_id = @confirmable_slots.index_with do |slot|
+        Annonces::AvailableTerrainsForSlotQuery.call(slot: slot)
+      end
+      return
+    end
+
+    slot = @annonce.slots.find(params[:slot_id])
+    terrain = params[:terrain]
+    result = Annonces::ConfirmationService.new(annonce: @annonce, slot: slot, terrain: terrain).call
+    Annonces::CreationNotifier.new(annonce: @annonce).notify_confirmed(session: result.session, users: result.registered)
+
+    notice = "Session de jeu libre créée 🎉 #{result.registered.size} joueur(s) inscrit(s)."
+    notice += " #{result.skipped.size} ignoré(s) (crédits/conflit)." if result.skipped.any?
+    redirect_to result.session, notice: notice
+  rescue ActiveRecord::RecordInvalid => e
+    redirect_to confirm_annonce_path(@annonce), alert: "Confirmation impossible : #{e.record.errors.full_messages.to_sentence.presence || e.message}"
+  end
+
+  def cancel
+    authorize! :cancel, @annonce
+    @annonce.cancelled!
+    redirect_to annonces_path, notice: "Annonce annulée."
+  end
+
+  private
+
+  def set_annonce
+    @annonce = Annonce.includes(:levels, slots: { availabilities: :user }).find(params[:id])
+  end
+
+  def current_slot_ids_for(user)
+    AnnonceAvailability
+      .where(annonce_slot_id: @annonce.slots.select(:id), user_id: user.id)
+      .pluck(:annonce_slot_id)
+      .to_set
+  end
+
+  def annonce_params
+    params.require(:annonce).permit(
+      :title, :description, :min_players,
+      level_ids: [],
+      slots_attributes: [ :id, :start_at, :end_at, :_destroy ]
+    )
+  end
+end

--- a/app/helpers/annonces_helper.rb
+++ b/app/helpers/annonces_helper.rb
@@ -1,0 +1,21 @@
+module AnnoncesHelper
+  # Ex. : « mardi 28 juillet 2026 à 10:00 → 12:00 »
+  def annonce_slot_range(slot)
+    return "" if slot.start_at.blank? || slot.end_at.blank?
+
+    "#{l(slot.start_at, format: :long)} → #{slot.end_at.strftime('%H:%M')}"
+  end
+
+  # Message WhatsApp pré-rempli pour lancer la discussion autour de la session.
+  def annonce_whatsapp_text(annonce, session)
+    players = session.participants.map(&:full_name).join(", ")
+    <<~MSG.strip
+      🏐 Jeu libre : #{session.title}
+      📅 #{l(session.start_at, format: :long)} → #{session.end_at.strftime('%H:%M')}
+      📍 #{session.terrain}
+      👥 #{players.presence || 'À confirmer'}
+
+      Rendez-vous : #{annonce_url(annonce)}
+    MSG
+  end
+end

--- a/app/javascript/controllers/nested_slots_controller.js
+++ b/app/javascript/controllers/nested_slots_controller.js
@@ -1,0 +1,33 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Ajout / suppression dynamique de créneaux dans le formulaire d'annonce.
+// Usage :
+//   <div data-controller="nested-slots">
+//     <template data-nested-slots-target="template"> ...ligne de créneau... </template>
+//     <div data-nested-slots-target="list"> ...lignes existantes... </div>
+//     <button data-action="nested-slots#add">Ajouter un créneau</button>
+export default class extends Controller {
+  static targets = ["list", "template"]
+
+  add(event) {
+    event.preventDefault()
+    const index = new Date().getTime()
+    const html = this.templateTarget.innerHTML.replace(/NEW_RECORD/g, index)
+    this.listTarget.insertAdjacentHTML("beforeend", html)
+  }
+
+  remove(event) {
+    event.preventDefault()
+    const row = event.target.closest("[data-nested-slots-row]")
+    if (!row) return
+
+    const destroyField = row.querySelector("input[name*='_destroy']")
+    if (destroyField) {
+      // Créneau déjà persisté : on le marque pour destruction et on le masque.
+      destroyField.value = "1"
+      row.style.display = "none"
+    } else {
+      row.remove()
+    }
+  }
+}

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -42,6 +42,12 @@ class Ability
         can :create, Registration
         can [ :destroy ], Registration, user_id: user.id
 
+        # Annonces de jeu libre : lecture/création pour tous les activés,
+        # gestion (édition, confirmation, annulation) réservée au créateur.
+        can [ :read, :create ], Annonce
+        can :toggle_availability, Annonce
+        can [ :update, :destroy, :confirm, :cancel ], Annonce, user_id: user.id
+
         # View own credit history
         can :read, CreditTransaction, user_id: user.id
       end

--- a/app/models/annonce.rb
+++ b/app/models/annonce.rb
@@ -1,0 +1,46 @@
+class Annonce < ApplicationRecord
+  belongs_to :user
+  belongs_to :session, optional: true
+
+  has_many :annonce_levels, dependent: :destroy
+  has_many :levels, through: :annonce_levels
+  has_many :slots, class_name: "AnnonceSlot", dependent: :destroy
+
+  accepts_nested_attributes_for :slots, allow_destroy: true, reject_if: :all_blank
+
+  enum :status, { open: 0, confirmed: 1, cancelled: 2 }
+
+  validates :title, presence: true
+  validates :min_players, numericality: { greater_than_or_equal_to: 1 }
+  validate :at_least_one_slot
+
+  scope :ordered_by_recent, -> { order(created_at: :desc) }
+
+  # Créneaux ayant atteint le quota minimum de joueurs disponibles.
+  def confirmable_slots
+    slots.select { |slot| slot.availabilities.size >= min_players }
+  end
+
+  # Vrai si au moins un créneau atteint le quota (annonce confirmable).
+  def confirmable?
+    open? && confirmable_slots.any?
+  end
+
+  # Badge indicatif : un responsable figure-t-il parmi les joueurs dispos sur ce créneau ?
+  def responsable_present?(slot)
+    slot.available_users.any?(&:responsable?)
+  end
+
+  # Nombre de joueurs distincts ayant répondu (au moins une dispo).
+  def participant_count
+    AnnonceAvailability.where(annonce_slot_id: slots.select(:id)).distinct.count(:user_id)
+  end
+
+  private
+
+  def at_least_one_slot
+    return unless slots.reject(&:marked_for_destruction?).empty?
+
+    errors.add(:base, "Une annonce doit proposer au moins un créneau")
+  end
+end

--- a/app/models/annonce_availability.rb
+++ b/app/models/annonce_availability.rb
@@ -1,0 +1,6 @@
+class AnnonceAvailability < ApplicationRecord
+  belongs_to :annonce_slot
+  belongs_to :user
+
+  validates :user_id, uniqueness: { scope: :annonce_slot_id }
+end

--- a/app/models/annonce_level.rb
+++ b/app/models/annonce_level.rb
@@ -1,0 +1,4 @@
+class AnnonceLevel < ApplicationRecord
+  belongs_to :annonce
+  belongs_to :level
+end

--- a/app/models/annonce_slot.rb
+++ b/app/models/annonce_slot.rb
@@ -1,0 +1,19 @@
+class AnnonceSlot < ApplicationRecord
+  belongs_to :annonce
+  has_many :availabilities, class_name: "AnnonceAvailability", dependent: :destroy
+  has_many :available_users, through: :availabilities, source: :user
+
+  validates :start_at, :end_at, presence: true
+  validate :end_at_after_start_at
+
+  scope :ordered_by_start, -> { order(:start_at) }
+
+  private
+
+  def end_at_after_start_at
+    return if start_at.blank? || end_at.blank?
+    return if end_at > start_at
+
+    errors.add(:end_at, "doit être après la date de début")
+  end
+end

--- a/app/queries/annonces/available_terrains_for_slot_query.rb
+++ b/app/queries/annonces/available_terrains_for_slot_query.rb
@@ -1,0 +1,33 @@
+module Annonces
+  # Terrains libres pour un créneau donné : ni chevauchés par une session
+  # existante (même formule d'overlap que Sessions::OverlappingOnTerrainQuery),
+  # ni fermés à cette date (TerrainClosure). Retourne les clés d'enum
+  # (« Terrain 1 », …) utilisables telles quelles pour Session#terrain.
+  class AvailableTerrainsForSlotQuery
+    def self.call(slot:)
+      new(slot: slot).call
+    end
+
+    def initialize(slot:)
+      @slot = slot
+    end
+
+    def call
+      Session.terrains.keys.reject { |terrain| occupied?(terrain) || closed?(terrain) }
+    end
+
+    private
+
+    attr_reader :slot
+
+    def occupied?(terrain)
+      Session.where(terrain: terrain)
+             .where("start_at < ? AND end_at > ?", slot.end_at, slot.start_at)
+             .exists?
+    end
+
+    def closed?(terrain)
+      TerrainClosure.covers?(terrain: terrain, date: slot.start_at.to_date)
+    end
+  end
+end

--- a/app/queries/annonces/eligible_annonces_query.rb
+++ b/app/queries/annonces/eligible_annonces_query.rb
@@ -1,0 +1,54 @@
+module Annonces
+  # Annonces ouvertes qu'un joueur donné est éligible à voir / rejoindre :
+  #   (a) niveau compatible — annonce sans niveau = visible par tous, sinon
+  #       le joueur doit partager au moins un niveau avec l'annonce ;
+  #   (b) au moins un créneau sans conflit avec l'agenda du joueur.
+  # Le créateur ne voit pas sa propre annonce via cette query (elle apparaît
+  # dans « mes annonces »).
+  class EligibleAnnoncesQuery
+    def self.call(user:, relation: Annonce.open)
+      new(user: user, relation: relation).call
+    end
+
+    def initialize(user:, relation:)
+      @user = user
+      @relation = relation
+    end
+
+    def call
+      level_matched.select { |annonce| slot_compatible?(annonce) }
+    end
+
+    private
+
+    attr_reader :user, :relation
+
+    def level_matched
+      base = relation.where.not(user_id: user.id).left_joins(:annonce_levels)
+      query = base.where(annonce_levels: { level_id: nil })
+
+      if user_level_ids.any?
+        query = query.or(base.where(annonce_levels: { level_id: user_level_ids }))
+      end
+
+      query.distinct.includes(slots: :availabilities)
+    end
+
+    def user_level_ids
+      @user_level_ids ||= user.levels.pluck(:id)
+    end
+
+    def slot_compatible?(annonce)
+      annonce.slots.any? { |slot| !conflicts?(slot) }
+    end
+
+    # Même formule d'overlap que Registrations::ScheduleConflictQuery.
+    def conflicts?(slot)
+      busy_ranges.any? { |busy_start, busy_end| busy_start < slot.end_at && busy_end > slot.start_at }
+    end
+
+    def busy_ranges
+      @busy_ranges ||= user.sessions_registered.pluck(:start_at, :end_at)
+    end
+  end
+end

--- a/app/services/annonces/confirmation_service.rb
+++ b/app/services/annonces/confirmation_service.rb
@@ -1,0 +1,70 @@
+module Annonces
+  # Transforme une annonce ouverte en une vraie Session de jeu libre sur le
+  # créneau retenu et le terrain choisi, puis inscrit + débite les joueurs
+  # disponibles sur ce créneau. Les joueurs insolvables ou en conflit d'agenda
+  # sont ignorés (retournés dans `skipped`), sans faire échouer l'ensemble.
+  #
+  #   result = Annonces::ConfirmationService.new(annonce:, slot:, terrain:).call
+  #   result.session   # la Session créée
+  #   result.registered / result.skipped  # joueurs inscrits / ignorés
+  class ConfirmationService
+    Result = Struct.new(:session, :registered, :skipped, keyword_init: true)
+
+    def initialize(annonce:, slot:, terrain:)
+      @annonce = annonce
+      @slot = slot
+      @terrain = terrain
+    end
+
+    def call
+      registered = []
+      skipped = []
+      session = nil
+
+      ActiveRecord::Base.transaction do
+        session = create_session!
+        slot.available_users.each do |user|
+          if register_player(user, session)
+            registered << user
+          else
+            skipped << user
+          end
+        end
+        annonce.update!(status: :confirmed, session: session)
+      end
+
+      Result.new(session: session, registered: registered, skipped: skipped)
+    end
+
+    private
+
+    attr_reader :annonce, :slot, :terrain
+
+    def create_session!
+      Session.create!(
+        title: annonce.title,
+        description: annonce.description,
+        session_type: :jeu_libre,
+        start_at: slot.start_at,
+        end_at: slot.end_at,
+        terrain: terrain,
+        user: annonce.user,
+        max_players: slot.available_users.size
+      )
+    end
+
+    # Inscription d'un joueur dans son propre savepoint : un échec (crédits
+    # insuffisants, conflit d'agenda) ne rejette que ce joueur, pas la session.
+    def register_player(user, session)
+      ActiveRecord::Base.transaction(requires_new: true) do
+        registration = Registration.new(user: user, session: session, status: :confirmed)
+        registration.save!
+        amount = registration.required_credits_for(user)
+        TransactionService.new(user, session, amount).create_transaction if amount.positive?
+      end
+      true
+    rescue ActiveRecord::RecordInvalid, ActiveRecord::StatementInvalid
+      false
+    end
+  end
+end

--- a/app/services/annonces/creation_notifier.rb
+++ b/app/services/annonces/creation_notifier.rb
@@ -1,0 +1,59 @@
+module Annonces
+  # Notifications push liées au cycle de vie d'une annonce :
+  #   - à la création : les joueurs éligibles sont prévenus ;
+  #   - à chaque nouvelle dispo : le créateur est prévenu ;
+  #   - à la confirmation : les joueurs inscrits reçoivent la session retenue.
+  class CreationNotifier
+    include Rails.application.routes.url_helpers
+
+    def initialize(annonce:)
+      @annonce = annonce
+    end
+
+    def notify_eligible_players
+      eligible_players.each do |user|
+        enqueue(user,
+                title: "Nouvelle annonce de jeu libre 🏐",
+                body: "#{annonce.user.full_name} cherche des joueurs : #{annonce.title}",
+                url: annonce_path(annonce))
+      end
+    end
+
+    def notify_creator_of_response(from:)
+      return if from == annonce.user
+
+      enqueue(annonce.user,
+              title: "Nouvelle dispo sur ton annonce 👍",
+              body: "#{from.full_name} est dispo pour « #{annonce.title} »",
+              url: annonce_path(annonce))
+    end
+
+    def notify_confirmed(session:, users:)
+      users.each do |user|
+        enqueue(user,
+                title: "Jeu libre confirmé 🎉",
+                body: "#{session.display_name} — #{I18n.l(session.start_at, format: :short)}, #{session.terrain}",
+                url: session_path(session))
+      end
+    end
+
+    private
+
+    attr_reader :annonce
+
+    # Joueurs éligibles à cette annonce précise (mêmes critères que l'index).
+    def eligible_players
+      User.where(id: candidate_ids).select do |user|
+        Annonces::EligibleAnnoncesQuery.call(user: user, relation: Annonce.where(id: annonce.id)).any?
+      end
+    end
+
+    def candidate_ids
+      User.activated.where.not(id: annonce.user_id).pluck(:id)
+    end
+
+    def enqueue(user, title:, body:, url:)
+      SendPushNotificationJob.perform_later(user.id, title: title, body: body, url: url)
+    end
+  end
+end

--- a/app/views/annonces/_annonce_card.html.erb
+++ b/app/views/annonces/_annonce_card.html.erb
@@ -1,0 +1,29 @@
+<% status_badge = { "open" => ["Ouverte", "bg-green-100 text-green-800"], "confirmed" => ["Confirmée", "bg-blue-100 text-blue-800"], "cancelled" => ["Annulée", "bg-gray-100 text-gray-600"] } %>
+<% label, badge_classes = status_badge[annonce.status] %>
+<%= link_to annonce_path(annonce), class: "block border border-gray-200 hover:border-asmbv-red transition-colors p-4 bg-white" do %>
+  <div class="flex items-start justify-between gap-3">
+    <div>
+      <h3 class="font-semibold text-gray-900"><%= annonce.title %></h3>
+      <p class="text-xs text-gray-500 mt-0.5">par <%= annonce.user.full_name %></p>
+    </div>
+    <span class="shrink-0 text-xs font-semibold px-2 py-1 <%= badge_classes %>"><%= label %></span>
+  </div>
+
+  <% if annonce.levels.any? %>
+    <div class="flex flex-wrap gap-1 mt-2">
+      <% annonce.levels.each do |level| %>
+        <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-700"><%= level.display_name %></span>
+      <% end %>
+    </div>
+  <% end %>
+
+  <ul class="mt-3 space-y-1">
+    <% annonce.slots.sort_by(&:start_at).first(3).each do |slot| %>
+      <li class="flex items-center gap-2 text-sm text-gray-700">
+        <%= lucide_icon("calendar", class: "size-4 text-gray-400") %>
+        <span><%= annonce_slot_range(slot) %></span>
+        <span class="text-xs text-gray-400">· <%= pluralize(slot.availabilities.size, "dispo") %></span>
+      </li>
+    <% end %>
+  </ul>
+<% end %>

--- a/app/views/annonces/_form.html.erb
+++ b/app/views/annonces/_form.html.erb
@@ -1,0 +1,68 @@
+<%= form_with model: annonce, class: "space-y-6" do |f| %>
+  <% if annonce.errors.any? %>
+    <div class="border border-red-300 bg-red-50 text-red-800 px-4 py-3 text-sm">
+      <p class="font-semibold mb-1"><%= pluralize(annonce.errors.count, "erreur") %> :</p>
+      <ul class="list-disc list-inside">
+        <% annonce.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div>
+    <label class="block text-sm font-semibold text-gray-700 mb-1">Titre</label>
+    <%= f.text_field :title, placeholder: "Ex. : Jeu libre détente", class: "w-full border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-asmbv-red" %>
+  </div>
+
+  <div>
+    <label class="block text-sm font-semibold text-gray-700 mb-1">Description <span class="font-normal text-gray-400">(optionnel)</span></label>
+    <%= f.text_area :description, rows: 3, class: "w-full border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-asmbv-red" %>
+  </div>
+
+  <div>
+    <label class="block text-sm font-semibold text-gray-700 mb-1">Nombre de joueurs visé</label>
+    <%= f.number_field :min_players, min: 1, class: "w-32 border border-gray-300 px-3 py-2 focus:outline-none focus:ring-2 focus:ring-asmbv-red" %>
+    <p class="text-xs text-gray-500 mt-1">L'annonce devient confirmable dès qu'un créneau atteint ce nombre de joueurs dispos.</p>
+  </div>
+
+  <div>
+    <label class="block text-sm font-semibold text-gray-700 mb-2">Niveaux ciblés <span class="font-normal text-gray-400">(aucun = ouvert à tous)</span></label>
+    <div class="flex flex-wrap gap-2">
+      <% Level.all.each do |level| %>
+        <label class="inline-flex items-center gap-2 border border-gray-200 px-3 py-2 text-sm cursor-pointer hover:border-asmbv-red">
+          <%= check_box_tag "annonce[level_ids][]", level.id, annonce.level_ids.include?(level.id), id: "annonce_level_#{level.id}" %>
+          <%= level.display_name %>
+        </label>
+      <% end %>
+    </div>
+  </div>
+
+  <div data-controller="nested-slots">
+    <div class="flex items-center justify-between mb-2">
+      <label class="block text-sm font-semibold text-gray-700">Créneaux proposés</label>
+      <button type="button" data-action="nested-slots#add"
+              class="inline-flex items-center gap-1 text-sm font-semibold text-asmbv-red hover:text-asmbv-red-dark">
+        <%= lucide_icon("plus", class: "size-4") %> Ajouter un créneau
+      </button>
+    </div>
+
+    <div class="space-y-3" data-nested-slots-target="list">
+      <%= f.fields_for :slots do |slot_form| %>
+        <%= render "slot_fields", slot_form: slot_form %>
+      <% end %>
+    </div>
+
+    <template data-nested-slots-target="template">
+      <%= f.fields_for :slots, AnnonceSlot.new, child_index: "NEW_RECORD" do |slot_form| %>
+        <%= render "slot_fields", slot_form: slot_form %>
+      <% end %>
+    </template>
+  </div>
+
+  <div class="flex items-center gap-3 pt-2">
+    <%= f.submit annonce.persisted? ? "Mettre à jour" : "Publier l'annonce",
+        class: "inline-flex items-center justify-center px-5 py-2.5 font-semibold text-white bg-asmbv-red hover:bg-asmbv-red-dark cursor-pointer" %>
+    <%= link_to "Annuler", (annonce.persisted? ? annonce_path(annonce) : annonces_path), class: "text-sm text-gray-500 hover:text-gray-700" %>
+  </div>
+<% end %>

--- a/app/views/annonces/_slot_fields.html.erb
+++ b/app/views/annonces/_slot_fields.html.erb
@@ -1,0 +1,18 @@
+<div class="grid grid-cols-1 sm:grid-cols-[1fr_1fr_auto] gap-3 items-end border border-gray-200 p-3" data-nested-slots-row>
+  <div>
+    <label class="block text-xs font-semibold text-gray-600 mb-1">Début</label>
+    <%= slot_form.datetime_field :start_at, class: "w-full border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-asmbv-red" %>
+  </div>
+  <div>
+    <label class="block text-xs font-semibold text-gray-600 mb-1">Fin</label>
+    <%= slot_form.datetime_field :end_at, class: "w-full border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-asmbv-red" %>
+  </div>
+  <div class="flex items-center gap-2">
+    <%= slot_form.hidden_field :_destroy %>
+    <button type="button" data-action="nested-slots#remove"
+            class="inline-flex items-center justify-center px-3 py-2 text-sm text-gray-500 hover:text-asmbv-red border border-gray-200 hover:border-asmbv-red"
+            title="Retirer ce créneau">
+      <%= lucide_icon("trash-2", class: "size-4") %>
+    </button>
+  </div>
+</div>

--- a/app/views/annonces/confirm.html.erb
+++ b/app/views/annonces/confirm.html.erb
@@ -1,0 +1,38 @@
+<div class="max-w-2xl mx-auto px-4 py-8">
+  <%= link_to annonce_path(@annonce), class: "inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-4" do %>
+    <%= lucide_icon("arrow-left", class: "size-4") %> Retour à l'annonce
+  <% end %>
+
+  <h1 class="text-2xl font-bold text-gray-900 mb-1">Confirmer « <%= @annonce.title %> »</h1>
+  <p class="text-sm text-gray-500 mb-6">Choisis le créneau et un terrain libre. La session de jeu libre sera créée et les joueurs disponibles inscrits (débit de <%= Session::FREE_PLAY_PRICE %> crédits chacun).</p>
+
+  <% if @confirmable_slots.empty? %>
+    <p class="text-sm text-gray-500 border border-dashed border-gray-200 p-6 text-center">Aucun créneau n'a encore atteint <%= @annonce.min_players %> joueurs.</p>
+  <% end %>
+
+  <div class="space-y-5">
+    <% @confirmable_slots.each do |slot| %>
+      <% terrains = @terrains_by_slot_id[slot] %>
+      <div class="border border-gray-200 p-4">
+        <div class="flex items-center gap-2 font-medium text-gray-900 mb-1">
+          <%= lucide_icon("calendar-clock", class: "size-5 text-gray-400") %>
+          <%= annonce_slot_range(slot) %>
+        </div>
+        <p class="text-sm text-gray-500 mb-3"><%= pluralize(slot.availabilities.size, "joueur") %> dispo<%= " · un responsable présent" if @annonce.responsable_present?(slot) %></p>
+
+        <% if terrains.any? %>
+          <%= form_with url: confirm_annonce_path(@annonce), method: :patch, class: "flex flex-wrap items-end gap-3" do %>
+            <%= hidden_field_tag :slot_id, slot.id %>
+            <div>
+              <label class="block text-xs font-semibold text-gray-600 mb-1">Terrain</label>
+              <%= select_tag :terrain, options_for_select(terrains), class: "border border-gray-300 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-asmbv-red" %>
+            </div>
+            <%= submit_tag "Confirmer cette session", class: "inline-flex items-center px-4 py-2 text-sm font-semibold text-white bg-green-600 hover:bg-green-700 cursor-pointer", data: { turbo_confirm: "Créer la session et inscrire les joueurs ?" } %>
+          <% end %>
+        <% else %>
+          <p class="text-sm text-red-700">Aucun terrain libre sur ce créneau (tous occupés ou fermés).</p>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/annonces/edit.html.erb
+++ b/app/views/annonces/edit.html.erb
@@ -1,0 +1,4 @@
+<div class="max-w-2xl mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold text-gray-900 mb-6">Modifier l'annonce</h1>
+  <%= render "form", annonce: @annonce %>
+</div>

--- a/app/views/annonces/index.html.erb
+++ b/app/views/annonces/index.html.erb
@@ -1,0 +1,37 @@
+<div class="max-w-5xl mx-auto px-4 py-8">
+  <div class="flex items-center justify-between mb-6">
+    <div>
+      <h1 class="text-2xl font-bold text-gray-900">Annonces de jeu libre</h1>
+      <p class="text-sm text-gray-500">Trouve des joueurs pour monter une session, ou réponds aux annonces des autres.</p>
+    </div>
+    <%= link_to new_annonce_path, class: "inline-flex items-center gap-2 px-4 py-2.5 font-semibold text-white bg-asmbv-red hover:bg-asmbv-red-dark shrink-0" do %>
+      <%= lucide_icon("plus", class: "size-5") %> Créer une annonce
+    <% end %>
+  </div>
+
+  <section class="mb-10">
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Annonces pour toi</h2>
+    <% if @eligible_annonces.any? %>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <% @eligible_annonces.each do |annonce| %>
+          <%= render "annonce_card", annonce: annonce %>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-sm text-gray-500 border border-dashed border-gray-200 p-6 text-center">Aucune annonce ne correspond à ton niveau et à tes disponibilités pour le moment.</p>
+    <% end %>
+  </section>
+
+  <section>
+    <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500 mb-3">Mes annonces</h2>
+    <% if @my_annonces.any? %>
+      <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <% @my_annonces.each do |annonce| %>
+          <%= render "annonce_card", annonce: annonce %>
+        <% end %>
+      </div>
+    <% else %>
+      <p class="text-sm text-gray-500 border border-dashed border-gray-200 p-6 text-center">Tu n'as pas encore créé d'annonce.</p>
+    <% end %>
+  </section>
+</div>

--- a/app/views/annonces/new.html.erb
+++ b/app/views/annonces/new.html.erb
@@ -1,0 +1,5 @@
+<div class="max-w-2xl mx-auto px-4 py-8">
+  <h1 class="text-2xl font-bold text-gray-900 mb-1">Nouvelle annonce de jeu libre</h1>
+  <p class="text-sm text-gray-500 mb-6">Propose un ou plusieurs créneaux : les joueurs éligibles seront prévenus et pourront indiquer leurs dispos.</p>
+  <%= render "form", annonce: @annonce %>
+</div>

--- a/app/views/annonces/show.html.erb
+++ b/app/views/annonces/show.html.erb
@@ -1,0 +1,96 @@
+<% is_owner = @annonce.user_id == current_user.id %>
+<% status_badge = { "open" => ["Ouverte", "bg-green-100 text-green-800"], "confirmed" => ["Confirmée", "bg-blue-100 text-blue-800"], "cancelled" => ["Annulée", "bg-gray-100 text-gray-600"] } %>
+<% label, badge_classes = status_badge[@annonce.status] %>
+
+<div class="max-w-3xl mx-auto px-4 py-8">
+  <%= link_to annonces_path, class: "inline-flex items-center gap-1 text-sm text-gray-500 hover:text-gray-700 mb-4" do %>
+    <%= lucide_icon("arrow-left", class: "size-4") %> Toutes les annonces
+  <% end %>
+
+  <div class="flex items-start justify-between gap-4">
+    <div>
+      <div class="flex items-center gap-3">
+        <h1 class="text-2xl font-bold text-gray-900"><%= @annonce.title %></h1>
+        <span class="text-xs font-semibold px-2 py-1 <%= badge_classes %>"><%= label %></span>
+      </div>
+      <p class="text-sm text-gray-500 mt-1">par <%= @annonce.user.full_name %></p>
+    </div>
+    <% if is_owner && @annonce.open? %>
+      <div class="flex items-center gap-2 shrink-0">
+        <%= link_to lucide_icon("pencil", class: "size-4"), edit_annonce_path(@annonce), class: "p-2 text-gray-500 hover:text-asmbv-red border border-gray-200", title: "Modifier" %>
+        <%= button_to lucide_icon("x", class: "size-4"), cancel_annonce_path(@annonce), method: :post, class: "p-2 text-gray-500 hover:text-asmbv-red border border-gray-200", form: { data: { turbo_confirm: "Annuler cette annonce ?" } }, title: "Annuler" %>
+      </div>
+    <% end %>
+  </div>
+
+  <% if @annonce.description.present? %>
+    <p class="mt-3 text-gray-700 whitespace-pre-line"><%= @annonce.description %></p>
+  <% end %>
+
+  <% if @annonce.levels.any? %>
+    <div class="flex flex-wrap gap-1 mt-3">
+      <% @annonce.levels.each do |level| %>
+        <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-700"><%= level.display_name %></span>
+      <% end %>
+    </div>
+  <% end %>
+
+  <% if @annonce.confirmed? && @annonce.session %>
+    <div class="mt-6 border border-blue-200 bg-blue-50 p-4">
+      <p class="font-semibold text-blue-900 mb-3">Session créée 🎉</p>
+      <div class="flex flex-col sm:flex-row gap-3">
+        <%= link_to "Voir la session", session_path(@annonce.session), class: "inline-flex items-center justify-center px-4 py-2 font-semibold text-white bg-asmbv-red hover:bg-asmbv-red-dark" %>
+        <%= render WhatsappShareComponent.new(text: annonce_whatsapp_text(@annonce, @annonce.session), full_width: false) %>
+      </div>
+    </div>
+  <% end %>
+
+  <h2 class="text-sm font-semibold uppercase tracking-wide text-gray-500 mt-8 mb-3">Créneaux proposés</h2>
+  <div class="space-y-4">
+    <% @annonce.slots.sort_by(&:start_at).each do |slot| %>
+      <% count = slot.availabilities.size %>
+      <% reached = count >= @annonce.min_players %>
+      <% i_am_in = @available_slot_ids.include?(slot.id) %>
+      <div class="border border-gray-200 p-4">
+        <div class="flex items-center justify-between gap-3 flex-wrap">
+          <div class="flex items-center gap-2 font-medium text-gray-900">
+            <%= lucide_icon("calendar-clock", class: "size-5 text-gray-400") %>
+            <%= annonce_slot_range(slot) %>
+          </div>
+          <div class="flex items-center gap-2">
+            <span class="text-sm font-semibold <%= reached ? 'text-green-700' : 'text-gray-500' %>">
+              <%= count %>/<%= @annonce.min_players %> joueurs
+            </span>
+            <% if @annonce.responsable_present?(slot) %>
+              <span class="text-xs font-semibold px-2 py-0.5 bg-amber-100 text-amber-800" title="Un responsable est disponible sur ce créneau">Responsable ✓</span>
+            <% end %>
+          </div>
+        </div>
+
+        <% if slot.available_users.any? %>
+          <div class="flex flex-wrap gap-1 mt-3">
+            <% slot.available_users.each do |u| %>
+              <span class="text-xs px-2 py-0.5 bg-gray-100 text-gray-700"><%= u.full_name %><%= " 🧑‍🏫" if u.responsable? %></span>
+            <% end %>
+          </div>
+        <% end %>
+
+        <% if @annonce.open? %>
+          <div class="mt-4 flex flex-wrap items-center gap-3">
+            <%= button_to toggle_availability_annonce_path(@annonce, slot_id: slot.id), method: :post,
+                  class: (i_am_in ? "inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold border border-gray-300 text-gray-700 hover:bg-gray-100" : "inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-asmbv-red hover:bg-asmbv-red-dark") do %>
+              <%= lucide_icon(i_am_in ? "user-minus" : "user-plus", class: "size-4") %>
+              <%= i_am_in ? "Retirer ma dispo" : "Je suis dispo" %>
+            <% end %>
+
+            <% if is_owner && reached %>
+              <%= link_to confirm_annonce_path(@annonce), class: "inline-flex items-center gap-2 px-4 py-2 text-sm font-semibold text-white bg-green-600 hover:bg-green-700" do %>
+                <%= lucide_icon("check", class: "size-4") %> Confirmer sur ce créneau
+              <% end %>
+            <% end %>
+          </div>
+        <% end %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/layouts/_navbar.html.erb
+++ b/app/views/layouts/_navbar.html.erb
@@ -17,6 +17,7 @@
         <% if current_user&.activated? %>
           <%= nav_link_navbar "Performances", performances_path %>
           <%= nav_link_navbar "Calendrier", sessions_path %>
+          <%= nav_link_navbar "Annonces", annonces_path %>
           <%= nav_link_navbar "Stages", stages_path %>
           <%= nav_link_navbar "Boutique", packs_path %>
           <%= nav_link_navbar "Profil", profile_path %>
@@ -106,6 +107,9 @@
                 <% end %>
                 <%= link_to sessions_path, class: navbar_mobile_link_class do %>
                   Calendrier
+                <% end %>
+                <%= link_to annonces_path, class: navbar_mobile_link_class do %>
+                  Annonces
                 <% end %>
                 <%= link_to stages_path, class: navbar_mobile_link_class do %>
                   Stages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,16 @@ Rails.application.routes.draw do
     resources :registrations, only: [ :create, :destroy ]
   end
 
+  # Annonces de jeu libre (« matcher » de joueurs)
+  resources :annonces do
+    member do
+      get :confirm
+      patch :confirm
+      post :cancel
+      post :toggle_availability
+    end
+  end
+
   resource :profile, only: [ :show ], controller: "users"
 
   namespace :me do

--- a/db/migrate/20260728100000_create_annonces.rb
+++ b/db/migrate/20260728100000_create_annonces.rb
@@ -1,0 +1,38 @@
+class CreateAnnonces < ActiveRecord::Migration[8.0]
+  def change
+    create_table :annonces do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :title, null: false
+      t.text :description
+      t.integer :status, null: false, default: 0
+      t.integer :min_players, null: false, default: 4
+      t.references :session, null: true, foreign_key: true
+
+      t.timestamps
+    end
+
+    create_table :annonce_slots do |t|
+      t.references :annonce, null: false, foreign_key: true
+      t.datetime :start_at, null: false
+      t.datetime :end_at, null: false
+
+      t.timestamps
+    end
+
+    create_table :annonce_availabilities do |t|
+      t.references :annonce_slot, null: false, foreign_key: true
+      t.references :user, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :annonce_availabilities, [ :annonce_slot_id, :user_id ], unique: true, name: "index_annonce_availabilities_on_slot_and_user"
+
+    create_table :annonce_levels do |t|
+      t.references :annonce, null: false, foreign_key: true
+      t.references :level, null: false, foreign_key: true
+
+      t.timestamps
+    end
+    add_index :annonce_levels, [ :annonce_id, :level_id ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_03_27_210235) do
+ActiveRecord::Schema[8.0].define(version: 2026_07_28_100000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -40,6 +40,48 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_27_210235) do
     t.bigint "blob_id", null: false
     t.string "variation_digest", null: false
     t.index ["blob_id", "variation_digest"], name: "index_active_storage_variant_records_uniqueness", unique: true
+  end
+
+  create_table "annonce_availabilities", force: :cascade do |t|
+    t.bigint "annonce_slot_id", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["annonce_slot_id", "user_id"], name: "index_annonce_availabilities_on_slot_and_user", unique: true
+    t.index ["annonce_slot_id"], name: "index_annonce_availabilities_on_annonce_slot_id"
+    t.index ["user_id"], name: "index_annonce_availabilities_on_user_id"
+  end
+
+  create_table "annonce_levels", force: :cascade do |t|
+    t.bigint "annonce_id", null: false
+    t.bigint "level_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["annonce_id", "level_id"], name: "index_annonce_levels_on_annonce_id_and_level_id", unique: true
+    t.index ["annonce_id"], name: "index_annonce_levels_on_annonce_id"
+    t.index ["level_id"], name: "index_annonce_levels_on_level_id"
+  end
+
+  create_table "annonce_slots", force: :cascade do |t|
+    t.bigint "annonce_id", null: false
+    t.datetime "start_at", null: false
+    t.datetime "end_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["annonce_id"], name: "index_annonce_slots_on_annonce_id"
+  end
+
+  create_table "annonces", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.string "title", null: false
+    t.text "description"
+    t.integer "status", default: 0, null: false
+    t.integer "min_players", default: 4, null: false
+    t.bigint "session_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["session_id"], name: "index_annonces_on_session_id"
+    t.index ["user_id"], name: "index_annonces_on_user_id"
   end
 
   create_table "balances", force: :cascade do |t|
@@ -193,6 +235,148 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_27_210235) do
     t.index ["user_id"], name: "index_sessions_on_user_id"
   end
 
+  create_table "solid_cable_messages", force: :cascade do |t|
+    t.binary "channel", null: false
+    t.binary "payload", null: false
+    t.datetime "created_at", null: false
+    t.bigint "channel_hash", null: false
+    t.index ["channel"], name: "index_solid_cable_messages_on_channel"
+    t.index ["channel_hash"], name: "index_solid_cable_messages_on_channel_hash"
+    t.index ["created_at"], name: "index_solid_cable_messages_on_created_at"
+  end
+
+  create_table "solid_cache_entries", force: :cascade do |t|
+    t.binary "key", null: false
+    t.binary "value", null: false
+    t.datetime "created_at", null: false
+    t.bigint "key_hash", null: false
+    t.integer "byte_size", null: false
+    t.index ["byte_size"], name: "index_solid_cache_entries_on_byte_size"
+    t.index ["key_hash", "byte_size"], name: "index_solid_cache_entries_on_key_hash_and_byte_size"
+    t.index ["key_hash"], name: "index_solid_cache_entries_on_key_hash", unique: true
+  end
+
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["concurrency_key", "priority", "job_id"], name: "index_solid_queue_blocked_executions_for_release"
+    t.index ["expires_at", "concurrency_key"], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index ["job_id"], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index ["process_id", "job_id"], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["active_job_id"], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index ["class_name"], name: "index_solid_queue_jobs_on_class_name"
+    t.index ["finished_at"], name: "index_solid_queue_jobs_on_finished_at"
+    t.index ["queue_name", "finished_at"], name: "index_solid_queue_jobs_for_filtering"
+    t.index ["scheduled_at", "finished_at"], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index ["queue_name"], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.index ["last_heartbeat_at"], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index ["name", "supervisor_id"], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index ["supervisor_id"], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index ["priority", "job_id"], name: "index_solid_queue_poll_all"
+    t.index ["queue_name", "priority", "job_id"], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index ["task_key", "run_at"], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["key"], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index ["static"], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index ["job_id"], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index ["scheduled_at", "priority", "job_id"], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["expires_at"], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index ["key", "value"], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index ["key"], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
   create_table "stages", force: :cascade do |t|
     t.string "title"
     t.text "description"
@@ -259,6 +443,13 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_27_210235) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "annonce_availabilities", "annonce_slots"
+  add_foreign_key "annonce_availabilities", "users"
+  add_foreign_key "annonce_levels", "annonces"
+  add_foreign_key "annonce_levels", "levels"
+  add_foreign_key "annonce_slots", "annonces"
+  add_foreign_key "annonces", "sessions"
+  add_foreign_key "annonces", "users"
   add_foreign_key "balances", "users"
   add_foreign_key "credit_purchases", "packs"
   add_foreign_key "credit_purchases", "users"
@@ -273,6 +464,12 @@ ActiveRecord::Schema[8.0].define(version: 2026_03_27_210235) do
   add_foreign_key "session_levels", "levels"
   add_foreign_key "session_levels", "sessions"
   add_foreign_key "sessions", "users"
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
   add_foreign_key "stages", "users", column: "assistant_coach_id"
   add_foreign_key "stages", "users", column: "main_coach_id"
   add_foreign_key "user_levels", "levels"

--- a/spec/factories/annonces.rb
+++ b/spec/factories/annonces.rb
@@ -1,0 +1,35 @@
+FactoryBot.define do
+  factory :annonce do
+    association :user
+    title { "Jeu libre détente" }
+    description { "On monte une session tranquille" }
+    status { :open }
+    min_players { 4 }
+
+    trait :confirmed do
+      status { :confirmed }
+    end
+
+    trait :cancelled do
+      status { :cancelled }
+    end
+
+    # Annonce avec un créneau déjà construit (demain 19h → 21h par défaut).
+    trait :with_slot do
+      after(:build) do |annonce|
+        annonce.slots << build(:annonce_slot, annonce: annonce)
+      end
+    end
+  end
+
+  factory :annonce_slot do
+    association :annonce
+    start_at { (Time.current + 1.day).change(hour: 19, min: 0) }
+    end_at   { (Time.current + 1.day).change(hour: 21, min: 0) }
+  end
+
+  factory :annonce_availability do
+    association :annonce_slot
+    association :user
+  end
+end

--- a/spec/models/annonce_spec.rb
+++ b/spec/models/annonce_spec.rb
@@ -1,0 +1,72 @@
+require 'rails_helper'
+
+RSpec.describe Annonce, type: :model do
+  describe 'validations' do
+    it 'is valid with a title and at least one slot' do
+      annonce = build(:annonce, :with_slot)
+      expect(annonce).to be_valid
+    end
+
+    it 'is invalid without a title' do
+      annonce = build(:annonce, :with_slot, title: nil)
+      expect(annonce).not_to be_valid
+      expect(annonce.errors[:title]).to be_present
+    end
+
+    it 'is invalid without any slot' do
+      annonce = build(:annonce)
+      expect(annonce).not_to be_valid
+      expect(annonce.errors[:base]).to include("Une annonce doit proposer au moins un créneau")
+    end
+  end
+
+  describe '#confirmable_slots / #confirmable?' do
+    let(:annonce) { create(:annonce, :with_slot, min_players: 2) }
+    let(:slot) { annonce.slots.first }
+
+    it 'is not confirmable below the quota' do
+      create(:annonce_availability, annonce_slot: slot)
+      expect(annonce.reload.confirmable_slots).to be_empty
+      expect(annonce).not_to be_confirmable
+    end
+
+    it 'is confirmable once a slot reaches min_players' do
+      2.times { create(:annonce_availability, annonce_slot: slot) }
+      annonce.reload
+      expect(annonce.confirmable_slots).to include(slot)
+      expect(annonce).to be_confirmable
+    end
+
+    it 'is not confirmable when the annonce is not open' do
+      2.times { create(:annonce_availability, annonce_slot: slot) }
+      annonce.update!(status: :cancelled)
+      expect(annonce.reload).not_to be_confirmable
+    end
+  end
+
+  describe '#responsable_present?' do
+    let(:annonce) { create(:annonce, :with_slot) }
+    let(:slot) { annonce.slots.first }
+
+    it 'is true when a responsable is available on the slot' do
+      create(:annonce_availability, annonce_slot: slot, user: create(:user, :responsable))
+      expect(annonce.responsable_present?(slot.reload)).to be(true)
+    end
+
+    it 'is false with only regular players' do
+      create(:annonce_availability, annonce_slot: slot, user: create(:user))
+      expect(annonce.responsable_present?(slot.reload)).to be(false)
+    end
+  end
+
+  describe '#participant_count' do
+    it 'counts distinct users across slots' do
+      annonce = create(:annonce, :with_slot)
+      slot = annonce.slots.first
+      user = create(:user)
+      create(:annonce_availability, annonce_slot: slot, user: user)
+      create(:annonce_availability, annonce_slot: slot, user: create(:user))
+      expect(annonce.participant_count).to eq(2)
+    end
+  end
+end

--- a/spec/queries/annonces/available_terrains_for_slot_query_spec.rb
+++ b/spec/queries/annonces/available_terrains_for_slot_query_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Annonces::AvailableTerrainsForSlotQuery do
+  let(:start_at) { (Time.current + 2.days).change(hour: 19, min: 0) }
+  let(:slot) { build(:annonce_slot, start_at: start_at, end_at: start_at + 2.hours) }
+
+  it "retourne tous les terrains quand aucun n'est occupé" do
+    expect(described_class.call(slot: slot)).to match_array(Session.terrains.keys)
+  end
+
+  it "exclut un terrain occupé par une session chevauchante" do
+    create(:session, :jeu_libre, terrain: "Terrain 1", start_at: start_at, end_at: start_at + 2.hours)
+    expect(described_class.call(slot: slot)).not_to include("Terrain 1")
+    expect(described_class.call(slot: slot)).to include("Terrain 2", "Terrain 3")
+  end
+
+  it "exclut un terrain fermé à cette date" do
+    TerrainClosure.create!(terrain: "Terrain 2", starts_on: start_at.to_date, ends_on: start_at.to_date)
+    expect(described_class.call(slot: slot)).not_to include("Terrain 2")
+  end
+end

--- a/spec/queries/annonces/eligible_annonces_query_spec.rb
+++ b/spec/queries/annonces/eligible_annonces_query_spec.rb
@@ -1,0 +1,60 @@
+require 'rails_helper'
+
+RSpec.describe Annonces::EligibleAnnoncesQuery do
+  let(:level)       { create(:level, name: "G1") }
+  let(:other_level) { create(:level, name: "G2") }
+  let(:player)      { create(:user, level: level) }
+
+  it "inclut une annonce sans niveau (ouverte à tous)" do
+    annonce = create(:annonce, :with_slot, user: create(:user))
+    expect(described_class.call(user: player)).to include(annonce)
+  end
+
+  it "inclut une annonce dont le niveau correspond au joueur" do
+    annonce = create(:annonce, :with_slot, user: create(:user), levels: [ level ])
+    expect(described_class.call(user: player)).to include(annonce)
+  end
+
+  it "exclut une annonce d'un niveau non partagé" do
+    annonce = create(:annonce, :with_slot, user: create(:user), levels: [ other_level ])
+    expect(described_class.call(user: player)).not_to include(annonce)
+  end
+
+  it "exclut sa propre annonce" do
+    annonce = create(:annonce, :with_slot, user: player)
+    expect(described_class.call(user: player)).not_to include(annonce)
+  end
+
+  it "exclut une annonce dont tous les créneaux entrent en conflit avec l'agenda du joueur" do
+    slot_start = (Time.current + 2.days).change(hour: 19, min: 0)
+    annonce = create(:annonce, user: create(:user),
+                     slots: [ build(:annonce_slot, start_at: slot_start, end_at: slot_start + 2.hours) ])
+
+    # Le joueur est déjà inscrit à une session chevauchant l'unique créneau.
+    create(:credit_transaction, user: player, amount: 10_000)
+    conflicting = create(:session, :jeu_libre, start_at: slot_start, end_at: slot_start + 2.hours)
+    create(:registration, user: player, session: conflicting)
+
+    expect(described_class.call(user: player)).not_to include(annonce)
+  end
+
+  it "inclut une annonce si au moins un créneau reste libre" do
+    free_start = (Time.current + 3.days).change(hour: 19, min: 0)
+    busy_start = (Time.current + 4.days).change(hour: 19, min: 0)
+    annonce = create(:annonce, user: create(:user), slots: [
+      build(:annonce_slot, start_at: busy_start, end_at: busy_start + 2.hours),
+      build(:annonce_slot, start_at: free_start, end_at: free_start + 2.hours)
+    ])
+
+    create(:credit_transaction, user: player, amount: 10_000)
+    conflicting = create(:session, :jeu_libre, start_at: busy_start, end_at: busy_start + 2.hours)
+    create(:registration, user: player, session: conflicting)
+
+    expect(described_class.call(user: player)).to include(annonce)
+  end
+
+  it "n'inclut que les annonces ouvertes" do
+    create(:annonce, :with_slot, :confirmed, user: create(:user))
+    expect(described_class.call(user: player)).to be_empty
+  end
+end

--- a/spec/requests/annonces_spec.rb
+++ b/spec/requests/annonces_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe "Annonces", type: :request do
+  let(:activated) { create(:user, activated_at: Time.current) }
+  let(:start_at) { (Time.current + 2.days).change(hour: 19, min: 0) }
+
+  describe "POST /annonces" do
+    let(:valid_params) do
+      {
+        annonce: {
+          title: "Jeu libre du soir",
+          min_players: 4,
+          slots_attributes: {
+            "0" => { start_at: start_at, end_at: start_at + 2.hours }
+          }
+        }
+      }
+    end
+
+    context "activated user" do
+      before { login_as(activated, scope: :user) }
+
+      it "creates an annonce owned by the current user" do
+        expect { post annonces_path, params: valid_params }.to change(Annonce, :count).by(1)
+        expect(Annonce.last.user).to eq(activated)
+        expect(response).to redirect_to(Annonce.last)
+      end
+
+      it "notifie les joueurs éligibles à la création" do
+        eligible = create(:user, activated_at: Time.current)
+        notifier = instance_double(Annonces::CreationNotifier, notify_eligible_players: true)
+        allow(Annonces::CreationNotifier).to receive(:new).and_return(notifier)
+
+        post annonces_path, params: valid_params
+
+        expect(notifier).to have_received(:notify_eligible_players)
+      end
+    end
+
+    context "non-activated user" do
+      before { login_as(create(:user), scope: :user) }
+
+      it "is forbidden" do
+        expect { post annonces_path, params: valid_params }.not_to change(Annonce, :count)
+      end
+    end
+  end
+
+  describe "POST /annonces/:id/toggle_availability" do
+    let(:annonce) { create(:annonce, :with_slot, user: create(:user)) }
+    let(:slot) { annonce.slots.first }
+
+    before { login_as(activated, scope: :user) }
+
+    it "adds then removes the current user's availability" do
+      expect {
+        post toggle_availability_annonce_path(annonce, slot_id: slot.id)
+      }.to change { AnnonceAvailability.where(annonce_slot: slot, user: activated).count }.from(0).to(1)
+
+      expect {
+        post toggle_availability_annonce_path(annonce, slot_id: slot.id)
+      }.to change { AnnonceAvailability.where(annonce_slot: slot, user: activated).count }.from(1).to(0)
+    end
+  end
+
+  describe "GET/PATCH /annonces/:id/confirm" do
+    let(:creator) { create(:user, activated_at: Time.current) }
+    let(:annonce) { create(:annonce, user: creator, min_players: 2, slots: [ build(:annonce_slot, start_at: start_at, end_at: start_at + 2.hours) ]) }
+    let(:slot) { annonce.slots.first }
+
+    before do
+      2.times do
+        u = create(:user)
+        create(:credit_transaction, user: u, amount: 10_000)
+        create(:annonce_availability, annonce_slot: slot, user: u)
+      end
+    end
+
+    it "confirme et crée une session (créateur uniquement)" do
+      login_as(creator, scope: :user)
+      expect {
+        patch confirm_annonce_path(annonce), params: { slot_id: slot.id, terrain: "Terrain 1" }
+      }.to change(Session, :count).by(1)
+      expect(annonce.reload).to be_confirmed
+      expect(response).to redirect_to(annonce.reload.session)
+    end
+
+    it "interdit la confirmation par un autre utilisateur" do
+      login_as(activated, scope: :user)
+      expect {
+        patch confirm_annonce_path(annonce), params: { slot_id: slot.id, terrain: "Terrain 1" }
+      }.to raise_error(CanCan::AccessDenied)
+      expect(Session.count).to eq(0)
+    end
+  end
+end

--- a/spec/requests/annonces_views_smoke_spec.rb
+++ b/spec/requests/annonces_views_smoke_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe "Annonces views smoke", type: :request do
+  let(:user) { create(:user, activated_at: Time.current) }
+  before { login_as(user, scope: :user) }
+
+  it "renders index" do
+    get annonces_path
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "renders new" do
+    get new_annonce_path
+    expect(response).to have_http_status(:ok)
+  end
+
+  it "renders show with a slot and toggle button" do
+    start_at = (Time.current + 2.days).change(hour: 19, min: 0)
+    annonce = create(:annonce, user: create(:user),
+                     slots: [build(:annonce_slot, start_at: start_at, end_at: start_at + 2.hours)])
+    get annonce_path(annonce)
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Je suis dispo")
+  end
+
+  it "renders confirm page for the owner" do
+    start_at = (Time.current + 2.days).change(hour: 19, min: 0)
+    annonce = create(:annonce, user: user, min_players: 1,
+                     slots: [build(:annonce_slot, start_at: start_at, end_at: start_at + 2.hours)])
+    create(:annonce_availability, annonce_slot: annonce.slots.first, user: create(:user))
+    get confirm_annonce_path(annonce)
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Terrain")
+  end
+
+  it "renders show with WhatsApp button when confirmed" do
+    start_at = (Time.current + 2.days).change(hour: 19, min: 0)
+    session = create(:session, :jeu_libre, start_at: start_at, end_at: start_at + 2.hours)
+    annonce = create(:annonce, :confirmed, user: user, session: session,
+                     slots: [build(:annonce_slot, start_at: start_at, end_at: start_at + 2.hours)])
+    get annonce_path(annonce)
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("wa.me")
+  end
+end

--- a/spec/services/annonces/confirmation_service_spec.rb
+++ b/spec/services/annonces/confirmation_service_spec.rb
@@ -1,0 +1,61 @@
+require 'rails_helper'
+
+RSpec.describe Annonces::ConfirmationService do
+  let(:creator) { create(:user) }
+  let(:start_at) { (Time.current + 2.days).change(hour: 19, min: 0) }
+  let(:annonce) { create(:annonce, user: creator, min_players: 2, slots: [ build(:annonce_slot, start_at: start_at, end_at: start_at + 2.hours) ]) }
+  let(:slot) { annonce.slots.first }
+
+  def available_player(credits: 10_000)
+    user = create(:user)
+    create(:credit_transaction, user: user, amount: credits) if credits.positive?
+    create(:annonce_availability, annonce_slot: slot, user: user)
+    user
+  end
+
+  it "crée une session de jeu libre sur le créneau et le terrain choisis" do
+    available_player
+    available_player
+
+    result = described_class.new(annonce: annonce, slot: slot, terrain: "Terrain 2").call
+
+    session = result.session
+    expect(session).to be_persisted
+    expect(session.session_type).to eq("jeu_libre")
+    expect(session.terrain).to eq("Terrain 2")
+    expect(session.start_at).to eq(start_at)
+    expect(session.user).to eq(creator)
+  end
+
+  it "inscrit et débite les joueurs solvables" do
+    p1 = available_player
+    p2 = available_player
+
+    result = described_class.new(annonce: annonce, slot: slot, terrain: "Terrain 1").call
+
+    expect(result.registered).to match_array([ p1, p2 ])
+    expect(result.session.participants).to match_array([ p1, p2 ])
+    expect(p1.reload.balance.amount).to eq(10_000 - Session::FREE_PLAY_PRICE)
+  end
+
+  it "ignore les joueurs insolvables sans faire échouer la session" do
+    solvent = available_player
+    broke = available_player(credits: 0)
+
+    result = described_class.new(annonce: annonce, slot: slot, terrain: "Terrain 1").call
+
+    expect(result.registered).to eq([ solvent ])
+    expect(result.skipped).to eq([ broke ])
+    expect(result.session.participants).to eq([ solvent ])
+  end
+
+  it "passe l'annonce en confirmed et la relie à la session" do
+    available_player
+    available_player
+
+    result = described_class.new(annonce: annonce, slot: slot, terrain: "Terrain 1").call
+
+    expect(annonce.reload).to be_confirmed
+    expect(annonce.session).to eq(result.session)
+  end
+end


### PR DESCRIPTION
## Contexte

Objectif business : faire jouer plus les joueurs → plus de jeu libre créé → plus de revenus pour le club.

Aujourd'hui une session de jeu libre ne peut être créée que par un coach/responsable/admin. Cette PR introduit l'**Annonce** : un joueur activé exprime une envie de jouer sur plusieurs créneaux, les joueurs éligibles répondent, et le créateur confirme pour transformer l'annonce en vraie session.

## Fonctionnement

1. Un joueur activé publie une **annonce** avec un ou plusieurs **créneaux** proposés (+ niveaux ciblés optionnels).
2. Les joueurs **éligibles** (niveau compatible **+** créneau sans conflit d'agenda) la voient et sont notifiés.
3. Chacun indique ses **disponibilités** par créneau. Le créateur est notifié à chaque réponse.
4. Dès qu'un créneau atteint le **minimum de joueurs**, le créateur **confirme** en choisissant un **terrain libre** (anti-overlap).
5. L'annonce devient une **`Session` jeu_libre** : joueurs disponibles inscrits + **débités de 300 crédits**, et un **lien WhatsApp pré-rempli** est proposé pour lancer la discussion.

## Choix de conception

- **Éligibilité** = niveau (réutilise la logique des entraînements) + créneau compatible (réutilise la formule d'overlap de `ScheduleConflictQuery`). Pas de mixité en v1.
- **Règle « 1 responsable / 4 joueurs »** : badge indicatif « Responsable présent », non bloquant.
- **Crédits** débités seulement à la confirmation, via le flux `TransactionService` existant. Les joueurs insolvables ou en conflit sont ignorés proprement (savepoints), sans faire échouer la session.
- **WhatsApp** : lien `wa.me/?text=…` pré-rempli, aucune API.
- **Navigation unidirectionnelle** respectée (pas de `has_many` retour depuis `Session`/`Level`).

## Contenu

- Migration + modèles `Annonce` / `AnnonceSlot` / `AnnonceAvailability` / `AnnonceLevel`
- Queries `EligibleAnnoncesQuery` et `AvailableTerrainsForSlotQuery`
- Service `Annonces::ConfirmationService` + notifier push (`CreationNotifier`)
- Controller + routes + permissions CanCanCan
- Vues Hotwire (créneaux dynamiques via Stimulus) + `WhatsappShareComponent` + lien dans la nav

## Tests

34 specs (modèle, queries, service, requêtes, smoke des vues) — **tous verts**, RuboCop clean.
Parcours complet vérifié dans le navigateur (création → réponses → confirmation → session + WhatsApp + débit crédits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)